### PR TITLE
Add examples to CI

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -27,7 +27,39 @@ jobs:
         - name: Build libTFLM using CCES ${{ matrix.cces_ver }}
           shell: bash
           run: 
-            make -j4 CCES=${{ env.CCES_PATH }}
+            make -j4 SHARCFX_ROOT=${{ env.CCES_PATH }}
+
+        - name: Build libadi_sharcfx_nn using CCES ${{ matrix.cces_ver }}
+          shell: bash
+          run: |
+            cd adi_sharcfx_nn/Project
+            make -j4 SHARCFX_ROOT=${{ env.CCES_PATH }}
+
+        - name: Build denoiser example project
+          shell: bash
+          run: |
+            cd Utils/automated-model-conversion/dtln
+            bash convert_models.sh
+            cd ../../../examples/denoiser/denoiser_fileio
+            make -j4 SHARCFX_ROOT=${{ env.CCES_PATH }}
+            cd ../denoiser_realtime
+            make -j4 SHARCFX_ROOT=${{ env.CCES_PATH }}
+
+        - name: Build kws example project
+          shell: bash
+          run: |
+            cd examples/keyword_spotter/kws_fileio
+            make -j4 SHARCFX_ROOT=${{ env.CCES_PATH }}
+            cd ../kws_realtime
+            make -j4 SHARCFX_ROOT=${{ env.CCES_PATH }}
+
+        - name: Build genre_id example project
+          shell: bash
+          run: |
+            cd Utils/automated-model-conversion/genre_identification
+            bash convert_models.sh
+            cd ../../../examples/genre_identification/genre_id_fileio
+            make -j4 SHARCFX_ROOT=${{ env.CCES_PATH }}
 
         - name: Test libTFLM artifact using CCES ${{ matrix.cces_ver }}
           shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ env
 .venv
 .env
 build
+tmp

--- a/Makefile
+++ b/Makefile
@@ -1,113 +1,45 @@
-CCES := /c/analog/cces/3.0.0
-CCES_VERSION := $(shell echo $(CCES) | grep -oP '\d+\.\d+\.\d+')
-ROOT_DIR := ./TFLM/src
+include ./tools/sharcfx/sharcfx.mk
 
-TARGET := ADSP-SC835
-CONFIG := RELEASE
 BUILD_DIR := ./build
-
-LIBNN := 
-LIBTFLM := $(BUILD_DIR)/libTFLM.a
-OBJ_LIST := $(BUILD_DIR)/objs.txt
-
-CCFX++ := $(CCES)/ccfx++
-CCFX := $(CCES)/ccfx
-XTAR := $(CCES)/Xtensa/XtensaTools/bin/xt-ar
+LIB_SRCS := ./TFLM/src
+LIB := libTFLM.a
 
 INCLUDES += \
-	-I"$(ROOT_DIR)/" \
-	-I"$(ROOT_DIR)/tensorflow/lite/schema" \
-	-I"$(ROOT_DIR)/tensorflow/lite/kernels/internal/optimized" \
-	-I"$(ROOT_DIR)/third_party" \
-	-I"$(ROOT_DIR)/third_party/kissfft" \
-	-I"$(ROOT_DIR)/third_party/kissfft/tools" \
-	-I"$(ROOT_DIR)/third_party/flatbuffers/include" \
-	-I"$(ROOT_DIR)/third_party/gemmlowp" \
-	-I"$(ROOT_DIR)/third_party/gemmlowp/internal" \
-	-I"$(ROOT_DIR)/third_party/ruy/ruy/profiler" \
-	-I"$(ROOT_DIR)/third_party/ruy" \
-	-I"$(ROOT_DIR)/third_party/gemmlowp/fixedpoint"  \
+	-I"$(LIB_SRCS)" \
+	-I"$(LIB_SRCS)/tensorflow/lite/schema" \
+	-I"$(LIB_SRCS)/tensorflow/lite/kernels/internal/optimized" \
+	-I"$(LIB_SRCS)/third_party" \
+	-I"$(LIB_SRCS)/third_party/kissfft" \
+	-I"$(LIB_SRCS)/third_party/kissfft/tools" \
+	-I"$(LIB_SRCS)/third_party/gemmlowp" \
+	-I"$(LIB_SRCS)/third_party/gemmlowp/internal" \
+	-I"$(LIB_SRCS)/third_party/flatbuffers/include" \
+	-I"$(LIB_SRCS)/third_party/ruy/ruy/profiler" \
+	-I"$(LIB_SRCS)/third_party/ruy" \
+	-I"$(LIB_SRCS)/third_party/gemmlowp/fixedpoint"  \
 	-I"./examples/shared" \
 	-I"./adi_sharcfx_nn/Include"
 
 C_SRCS += \
-	$(wildcard $(ROOT_DIR)/third_party/kissfft/tools/*.c) \
-	$(wildcard $(ROOT_DIR)/third_party/kissfft/*.c) \
-	$(wildcard $(ROOT_DIR)/tensorflow/lite/experimental/microfrontend/lib/*.c) \
-	$(wildcard $(ROOT_DIR)/tensorflow/lite/kernels/internal/optimized/*.c) \
+	$(wildcard $(LIB_SRCS)/third_party/kissfft/tools/*.c) \
+	$(wildcard $(LIB_SRCS)/third_party/kissfft/*.c) \
+	$(wildcard $(LIB_SRCS)/tensorflow/lite/experimental/microfrontend/lib/*.c) \
+	$(wildcard $(LIB_SRCS)/tensorflow/lite/kernels/internal/optimized/*.c) \
 	$(wildcard ./examples/shared/*.c)
 
 CC_SRCS += \
-	$(wildcard $(ROOT_DIR)/tensorflow/lite/schema/*.cc) \
-	$(wildcard $(ROOT_DIR)/tensorflow/lite/micro/tflite_bridge/*.cc) \
-	$(wildcard $(ROOT_DIR)/tensorflow/lite/micro/models/*.cc) \
-	$(wildcard $(ROOT_DIR)/tensorflow/lite/micro/memory_planner/*.cc) \
-	$(wildcard $(ROOT_DIR)/tensorflow/lite/micro/kernels/*.cc) \
-	$(wildcard $(ROOT_DIR)/tensorflow/lite/micro/arena_allocator/*.cc) \
-	$(wildcard $(ROOT_DIR)/tensorflow/lite/micro/*.cc) \
-	$(wildcard $(ROOT_DIR)/tensorflow/lite/kernels/internal/reference/*.cc) \
-	$(wildcard $(ROOT_DIR)/tensorflow/lite/kernels/internal/*.cc) \
-	$(wildcard $(ROOT_DIR)/tensorflow/lite/kernels/*.cc) \
-	$(wildcard $(ROOT_DIR)/tensorflow/lite/experimental/microfrontend/lib/*.cc) \
-	$(wildcard $(ROOT_DIR)/tensorflow/lite/core/c/*.cc) \
-	$(wildcard $(ROOT_DIR)/tensorflow/lite/core/api/*.cc)
+	$(wildcard $(LIB_SRCS)/tensorflow/lite/schema/*.cc) \
+	$(wildcard $(LIB_SRCS)/tensorflow/lite/micro/tflite_bridge/*.cc) \
+	$(wildcard $(LIB_SRCS)/tensorflow/lite/micro/models/*.cc) \
+	$(wildcard $(LIB_SRCS)/tensorflow/lite/micro/memory_planner/*.cc) \
+	$(wildcard $(LIB_SRCS)/tensorflow/lite/micro/kernels/*.cc) \
+	$(wildcard $(LIB_SRCS)/tensorflow/lite/micro/arena_allocator/*.cc) \
+	$(wildcard $(LIB_SRCS)/tensorflow/lite/micro/*.cc) \
+	$(wildcard $(LIB_SRCS)/tensorflow/lite/kernels/internal/reference/*.cc) \
+	$(wildcard $(LIB_SRCS)/tensorflow/lite/kernels/internal/*.cc) \
+	$(wildcard $(LIB_SRCS)/tensorflow/lite/kernels/*.cc) \
+	$(wildcard $(LIB_SRCS)/tensorflow/lite/experimental/microfrontend/lib/*.cc) \
+	$(wildcard $(LIB_SRCS)/tensorflow/lite/core/c/*.cc) \
+	$(wildcard $(LIB_SRCS)/tensorflow/lite/core/api/*.cc)
 
-CPP_SRCS+= \
-	$(wildcard $(ROOT_DIR)/tensorflow/lite/kernels/internal/optimized/*.cpp)
-
-C_OBJS = $(patsubst %.c,$(BUILD_DIR)/%.o,$(subst ./,,$(C_SRCS)))
-CC_OBJS = $(patsubst %.cc,$(BUILD_DIR)/%.o,$(subst ./,,$(CC_SRCS)))
-CPP_OBJS = $(patsubst %.cpp,$(BUILD_DIR)/%.o,$(subst ./,,$(CPP_SRCS)))
-
-SRC_OBJS = $(C_OBJS) $(CC_OBJS) $(CPP_OBJS)
-
-C_DEPS := $(C_OBJS:.o=.d)
-CC_DEPS := $(CC_OBJS:.o=.d)
-
-ifeq ($(CONFIG), RELEASE)
-	FLAGS = -proc $(TARGET) -si-revision 0.0 -c -O3 -LNO:simd -ffunction-sections -fdata-sections -fno-math-errno -mlongcalls -DCORE1 -DUART_REDIRECT -DNDEBUG $(INCLUDES) -MMD -MP
-else
-	FLAGS = -proc $(TARGET) -si-revision 0.0 -c -ffunction-sections -fdata-sections -fno-math-errno -mlongcalls -g -DCORE1 -D_DEBUG $(INCLUDES) -MMD -MP
-endif
-
-CC_FLAGS = $(FLAGS) -std=c++11 -stdlib=libc++
-C_FLAGS = $(FLAGS) -std=c11
-
-all: prebuild $(LIBTFLM) postbuild
-
-clean: 
-	@echo '[RM] $(BUILD_DIR)'
-	@rm -rf $(BUILD_DIR)
-
-prebuild:
-	@echo 'Building $(LIBTFLM) for $(TARGET) in $(CONFIG) configuration'
-	@echo 'Using CCES Version $(CCES_VERSION)'
-	@echo
-
-postbuild:
-
-$(LIBTFLM): $(SRC_OBJS)
-	@echo '[AR] Archiving to $(LIBTFLM)'
-	@$(XTAR) -r $(LIBTFLM) @$(OBJ_LIST)
-	@echo
-	@echo '[AR] Done. See $(LIBTFLM)'
-
-$(BUILD_DIR)/%.o: %.c
-	@mkdir -p $(dir $@)
-	@echo '[CC] $<'
-	@$(CCFX) $(C_FLAGS) -MF"$(@:%.o=%.d)" -MT"$(@)" -o  "$@" "$<"
-	@echo "\"./$@\"" >> $(OBJ_LIST)
-
-$(BUILD_DIR)/%.o: %.cc
-	@mkdir -p $(dir $@)
-	@echo '[CX] $<'
-	@$(CCFX++) $(CC_FLAGS) -MF"$(@:%.o=%.d)" -MT"$(@)" -o  "$@" "$<"
-	@echo "\"./$@\"" >> $(OBJ_LIST)
-
-$(BUILD_DIR)/%.o: %.cpp
-	@mkdir -p $(dir $@)
-	@echo '[CX] $<'
-	@$(CCFX++) $(CC_FLAGS) -MF"$(@:%.o=%.d)" -MT"$(@)" -o  "$@" "$<"
-	@echo "\"./$@\"" >> $(OBJ_LIST)
-
-.PHONY: all clean prebuild postbuild
+include ./tools/sharcfx/lib.mk

--- a/README.md
+++ b/README.md
@@ -60,7 +60,10 @@ To build the project, you will need to download and install the following softwa
 # Building the example application
 
 ### About the example applications
-The [examples](examples) folder includes the SHARC-FX port for the DTLN(Dual-signal Transformation LSTM Network) denoiser application. This example utilizes the ADAU1979 ADC and the ADAU1962A DAC to operate in I2S mode for audio talkthrough that has been leveraged to run the DTLN denoiser in realtime. 
+The [examples](examples) folder includes the SHARC-FX port for the following applications:
+ * [DTLN (Dual-signal Transformation LSTM Network) denoiser](examples/denoiser)
+ * [CNN genre identification](examples/genre_identification)
+ * [DS-CNN keyword spotting](examples/keyword_spotter)
 
 Building the example application is a two-stage process. First, you will need to build the static library archive (`libTFLM.a`). The generated library archive is then linked and built together with the example application project to create the executable file. To illustrate: 
 
@@ -93,33 +96,52 @@ Next, build the `libTFLM.a` file:
 At this point, you should have a `libTFLM.a` library archive located inside the `Debug` or `Release` folder.
 
 Instructions to build and run the examples are found in their respective READMEs.
-- [Denoiser Real-time](examples/denoiser_realtime/README.md)
-- [Denoiser File I/O](examples/denoiser_fileio/README.md)
+- [Denoiser](examples/denoiser/README.md)
+- [Keyword Spotting](examples/keyword_spotter/README.md)
+- [Genre Identification](examples/genre_identification/README.md)
 
-We have also included utilities for automated model conversion for the DTLN model. These are available in the [utils](Utils) directory. 
-- [Automated model conversion for DTLN](Utils/automated-model-conversion-dtln/README.md)
-
+We have also included utilities for automated model conversion and flashing. These are available in the [utils](Utils) directory. 
+- [Automated model conversion for DTLN](Utils/automated-model-conversion/dtln/README.md)
+- [Automated model conversion for Genre ID](Utils/automated-model-conversion/genre_identification/README.md)
+- [Flashing](Utils/flashing-tools/README.md)
 
 ### Option 2: via the Headless build 
 
-We also provide a CLI-based build workflow that is equivalent to the IDE-based workflow in the CCES ecosystem. At the monent, the headless interface only supports the building `libTFLM.a` library archive. Support to build the examples and generate the *.dxe executables will be included in future releases. 
+We also provide a CLI-based build workflow that is equivalent to the IDE-based workflow in the CCES ecosystem. The headless interface supports building the `libTFLM.a` library archive.
 
 To build the library archive for TFLM with the optimized kernels, run make on the top-level directory:
 ```
 make
 ```
 
-By default, the build script uses `/c/analog/cces` as the CCES search path for the SHARC-FX toolchains and the default target is for the [ADSP-SC835](https://www.analog.com/en/products/adsp-sc835.html). </br> `RELEASE` is the default configuration but you may also select to `DEBUG` configuration mode.
+By default, the build script uses `/c/analog/cces` as the search path for the SHARC-FX toolchains and the default target is for the [ADSP-SC835](https://www.analog.com/en/products/adsp-sc835.html). </br> `RELEASE` is the default configuration but you may also select to `DEBUG` configuration mode.
 
 To configure these, run
 ```
-make CCES=</path/to/cces> TARGET=<DEVICE_NAME> CONFIG=<CONFIG_MODE>
+make SHARCFX_ROOT=</path/to/cces> DEVICE=<DEVICE_NAME> CONFIG=<CONFIG_MODE>
 ```
+
 The script will output a `./build/libTFLM.a` library which can be linked to other projects using the `-lTFLM` flag. 
 
 Build objects are stored in the `./build` directory. To remove these, run
 ```
 make clean
+```
+
+The headless interface also allows building and flashing an example project. To build an example application:
+```
+cd examples/<example_project>/<example_realtime|fileio>
+make
+```
+
+To flash to the board with a debugger, run
+```
+make flash
+```
+
+The default debugger is ICE-1000. To configure this with other debugger like the ICE-2000, run
+```
+make flash DEBUGGER=2000
 ```
 
 # Getting Help

--- a/Utils/automated-model-conversion/dtln/convert_models.sh
+++ b/Utils/automated-model-conversion/dtln/convert_models.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+# Variables
+dtln="dtln"
+env="python_env"
+model1_h="model_float_1_data.h"
+model1_cc="model_float_1_data.cc"
+model2_h="model_float_2_data.h"
+model2_cc="model_float_2_data.cc"
+
+# Directories
+model_dir="./TFLM_models"
+example_model_dir="../../../examples/denoiser/common/model/model_fp"
+
+# Check if models are already generated
+if [[ -f "$model_dir/$model1_h" && -f "$model_dir/$model1_cc" && -f "$model_dir/$model2_h" && -f "$model_dir/$model2_cc" ]]; then
+        echo "TFLM models have been generated successfully"
+else
+    # Clone the project if not present
+    if [[ ! -d "$dtln" ]]; then
+        git clone https://github.com/breizhn/DTLN.git "$dtln"
+    else
+        echo "Project directory already present, moving to next step"
+    fi
+
+    # Copy necessary files
+    cp ./scripts/DTLN_model.py "$dtln/DTLN_model.py"
+    cp ./scripts/input1.npy "$dtln/input1.npy"
+    cp ./scripts/input2.npy "$dtln/input2.npy"
+    cp ./scripts/state1.npy "$dtln/state1.npy"
+    cp ./scripts/state2.npy "$dtln/state2.npy"
+    cp ./scripts/fix_error.py "$dtln/fix_error.py"
+
+    # Navigate to project folder
+    cd "$dtln"
+
+    # Set up Python environment
+    python -m pip install --user virtualenv --no-cache-dir
+    python -m venv "$env"
+    source "$env/scripts/activate"
+    python -m pip install --upgrade pip --no-cache-dir
+    python -m pip install tensorflow==2.15.0 soundfile wavinfo --no-cache-dir
+
+    # Run Python scripts
+    python fix_error.py
+    python convert_weights_to_tf_lite.py -m pretrained_model/model.h5 -t model_float
+
+    # Copy generated TFLite models
+    cp model_float_1.tflite ../scripts/
+    cp model_float_2.tflite ../scripts/
+
+    # Navigate to scripts folder
+    cd ../scripts
+
+    # Generate C arrays if TFLM models folder doesn't exist
+    if [[ ! -d "../$model_dir" ]]; then
+        python generate_cc_arrays.py . model_float_1.tflite
+        python generate_cc_arrays.py . model_float_2.tflite
+    fi
+
+    # Clean up and move TFLM models
+    mkdir ../$model_dir
+    mv $model1_cc "../$model_dir/$model1_cc"
+    mv $model1_h "../$model_dir/$model1_h"
+    mv $model2_cc "../$model_dir/$model2_cc"
+    mv $model2_h "../$model_dir/$model2_h"
+    rm -f model_float_1.tflite model_float_2.tflite
+
+    # Remove repository
+    cd ..
+    rm -rf "$dtln"
+
+    # Check if TFLM models were generated successfully
+    if [[ -f "$model_dir/$model1_h" && -f "$model_dir/$model1_cc" && -f "$model_dir/$model2_cc" && -f "$model_dir/$model1_h" ]]; then
+        echo "TFLM models have been generated successfully"
+    fi
+fi
+
+# Copy models to example project
+cp "$model_dir/$model1_cc" "$example_model_dir/$model1_cc"
+cp "$model_dir/$model1_h" "$example_model_dir/$model1_h"
+cp "$model_dir/$model2_cc" "$example_model_dir/$model2_cc"
+cp "$model_dir/$model2_h" "$example_model_dir/$model2_h"
+
+# Verify copied models
+if [[ -f "$example_model_dir/$model1_cc" && -f "$example_model_dir/$model1_h" && -f "$example_model_dir/$model2_cc" && -f "$example_model_dir/$model2_h" ]]; then
+    echo "TFLM models have been copied into respective projects successfully, check the following paths to find the models:"
+    echo "$example_model_dir"
+fi

--- a/Utils/automated-model-conversion/genre_identification/convert_models.sh
+++ b/Utils/automated-model-conversion/genre_identification/convert_models.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+# Variables
+project_folder="music-genre-classification"
+env="python_env"
+tflite_model_float32="float32_genre_ID.tflite"
+tflite_model_int8="int8_genre_ID.tflite"
+tflm_model1a="float32_genre_ID_model_data.h"
+tflm_model1b="float32_genre_ID_model_data.cc"
+tflm_model2a="int8_genre_ID_model_data.h"
+tflm_model2b="int8_genre_ID_model_data.cc"
+
+# Directories
+tflm_models="TFLM_models"
+final_int8_model_path="../../../examples/genre_identification/common/model/int8_genre_ID/"
+final_float_model_path="../../../examples/genre_identification/common/model/float_genre_ID/"
+
+# Check if TFLM models exist
+if [[ -f "$tflm_models/$tflm_model1a" && -f "$tflm_models/$tflm_model1b" && -f "$tflm_models/$tflm_model2a" && -f "$tflm_models/$tflm_model2b" ]]; then
+    echo "TFLM models have been generated successfully"
+else
+    # Clone the project if not present
+    if [[ ! -d "$project_folder" ]]; then
+        git clone https://github.com/cetinsamet/music-genre-classification.git "$project_folder"
+    else
+        echo "Project directory already present, moving to next step"
+    fi
+
+    # Navigate to scripts folder
+    cd "scripts"
+
+    # Set up Python environment
+    if [[ ! -d "$env" ]]; then
+        python -m pip install --user virtualenv --no-cache-dir
+        python -m venv "$env"
+        source "$env/scripts/activate"
+        python -m pip install --upgrade pip --no-cache-dir
+        cp requirements.txt reqs.txt
+        sed -i '/tensorflow-intel==2.15.0/d' reqs.txt
+        python -m pip install -r reqs.txt --no-cache-dir
+        rm reqs.txt
+    fi
+
+    # Generate TFLite models if not already present
+    if [[ ! -f "$tflite_model_int8" ]]; then
+        source "$env/scripts/activate"
+        python convert_model.py
+    fi
+
+    # Generate TFLM models if not already present
+    if [[ ! -d "$tflm_models" ]]; then
+        python generate_cc_arrays.py . "$tflite_model_float32"
+        python generate_cc_arrays.py . "$tflite_model_int8"
+    fi
+
+    # Clean up and move TFLM models
+    mkdir ../$tflm_models
+    mv $tflm_model1a ../$tflm_models/$tflm_model1a
+    mv $tflm_model1b ../$tflm_models/$tflm_model1b
+    mv $tflm_model2a ../$tflm_models/$tflm_model2a
+    mv $tflm_model2b ../$tflm_models/$tflm_model2b
+    rm -f "$tflite_model_float32" "$tflite_model_int8"
+
+    # Reclaim space
+    echo "Reclaiming space..."
+    deactivate
+    rm -rf "$env"
+    cd ..
+    rm -rf "$project_folder"
+
+    # Check if TFLM models were generated successfully
+    if [[ -f "$tflm_models/$tflm_model1a" && -f "$tflm_models/$tflm_model1b" && -f "$tflm_models/$tflm_model2a" && -f "$tflm_models/$tflm_model2b" ]]; then
+        echo "TFLM models have been generated successfully"
+    fi
+fi
+
+# Copy models to final paths
+cp "$tflm_models/$tflm_model2a" "$final_int8_model_path/$tflm_model2a"
+cp "$tflm_models/$tflm_model2b" "$final_int8_model_path/$tflm_model2b"
+cp "$tflm_models/$tflm_model1a" "$final_float_model_path/$tflm_model1a"
+cp "$tflm_models/$tflm_model1b" "$final_float_model_path/$tflm_model1b"
+
+# Verify copied models
+if [[ -f "$final_float_model_path/$tflm_model1a" && -f "$final_float_model_path/$tflm_model1b" && -f "$final_int8_model_path/$tflm_model2a" && -f "$final_int8_model_path/$tflm_model2b" ]]; then
+    echo "TFLM models have been copied into respective projects successfully, check the following paths to find the models:"
+    echo "$final_int8_model_path"
+    echo "$final_float_model_path"
+fi

--- a/adi_sharcfx_nn/Project/Makefile
+++ b/adi_sharcfx_nn/Project/Makefile
@@ -1,0 +1,14 @@
+include ../../tools/sharcfx/sharcfx.mk
+
+BUILD_DIR := ./build
+LIB_SRCS := .
+LIB := libadi_sharcfx_nn.a
+
+INCLUDES += \
+	-I"../Include" \
+	-I"../../examples/shared"
+
+CPP_SRCS += \
+	$(wildcard $(LIB_SRCS)/src/*.cpp)
+
+include ../../tools/sharcfx/lib.mk

--- a/examples/denoiser/denoiser_fileio/Makefile
+++ b/examples/denoiser/denoiser_fileio/Makefile
@@ -1,0 +1,39 @@
+include ../../../tools/sharcfx/sharcfx.mk
+
+# Initialize project root and build directory
+PROJECT := denoiser_fileio
+PROJECT_ROOT := .
+BUILD_DIR := ./build
+DEBUGGER := 1000
+
+# Shared and common source files
+SHARED := ../../shared
+COMMON := ../common
+
+# Add include directories
+INCLUDES += \
+	-I"$(PROJECT_ROOT)/src" \
+	-I"$(PROJECT_ROOT)/system" \
+	-I"$(COMMON)/model/model_fp" \
+	-I"$(SHARED)/system" \
+	-I"$(SHARED)"
+
+# Add C sources
+C_SRCS += \
+	$(wildcard $(PROJECT_ROOT)/system/*.c) \
+	$(wildcard $(PROJECT_ROOT)/system/pinmux/GeneratedSources/*.c) \
+	$(wildcard $(PROJECT_ROOT)/system/startup_lsp/lsp/*.c) \
+	$(wildcard $(PROJECT_ROOT)/system/sru/*.c) \
+	$(wildcard $(SHARED)/system/*.c) \
+	$(wildcard $(SHARED)/*.c) \
+	$(wildcard $(COMMON)/*.c)
+
+# Add C++ sources (.cc)
+CC_SRCS += \
+	$(wildcard $(COMMON)/model/model_fp/*.cc)
+
+# Add C++ sources (.cpp)
+CPP_SRCS += \
+	$(wildcard $(PROJECT_ROOT)/src/*.cpp)
+
+include ../../../tools/sharcfx/project.mk

--- a/examples/denoiser/denoiser_realtime/Makefile
+++ b/examples/denoiser/denoiser_realtime/Makefile
@@ -1,0 +1,52 @@
+include ../../../tools/sharcfx/sharcfx.mk
+
+# Initialize project root and build directory
+PROJECT := denoiser_realtime
+PROJECT_ROOT := .
+BUILD_DIR := ./build
+DEBUGGER := 1000
+
+# Shared and common source files
+SHARED := ../../shared
+COMMON := ../common
+
+# Add include directories
+INCLUDES += \
+	-I"$(PROJECT_ROOT)/src" \
+	-I"$(PROJECT_ROOT)/system" \
+	-I"$(PROJECT_ROOT)/system/drivers/sport" \
+	-I"$(PROJECT_ROOT)/system/drivers/twi" \
+	-I"$(PROJECT_ROOT)/system/services/pdma" \
+	-I"$(COMMON)/model/model_fp" \
+	-I"$(SHARED)/system" \
+	-I"$(SHARED)"
+
+# Add C sources
+C_SRCS += \
+	$(wildcard $(PROJECT_ROOT)/system/*.c) \
+	$(wildcard $(PROJECT_ROOT)/system/pinmux/GeneratedSources/*.c) \
+	$(wildcard $(PROJECT_ROOT)/system/startup_lsp/lsp/*.c) \
+	$(wildcard $(PROJECT_ROOT)/system/sru/*.c) \
+	$(wildcard $(SHARED)/system/*.c) \
+	$(wildcard $(SHARED)/*.c) \
+	$(wildcard $(COMMON)/*.c)
+
+# Add C++ sources (.cc)
+CC_SRCS += \
+	$(wildcard $(COMMON)/model/model_fp/*.cc)
+
+# Add C++ sources (.cpp)
+CPP_SRCS += \
+	$(wildcard $(PROJECT_ROOT)/src/*.cpp)
+
+# Add drivers and services
+SYSCFG_SRCS += \
+	$(DRIVER_DIR)/Source/sport/adi_sport.c \
+	$(DRIVER_DIR)/Source/twi/adi_twi.c \
+	$(DRIVER_DIR)/Source/uart/adi_uart.c \
+	$(SERVICE_DIR)/Source/pdma/adi_pdma.c \
+	$(SERVICE_DIR)/Source/gpio/adi_gpio.c \
+	$(SERVICE_DIR)/Source/pwr/adi_pwr.c \
+	$(SERVICE_DIR)/Source/spu/adi_spu.c
+
+include ../../../tools/sharcfx/project.mk

--- a/examples/genre_identification/genre_id_fileio/Makefile
+++ b/examples/genre_identification/genre_id_fileio/Makefile
@@ -1,0 +1,42 @@
+include ../../../tools/sharcfx/sharcfx.mk
+
+# Initialize project root and build directory
+PROJECT := genre_id_fileio
+PROJECT_ROOT := .
+BUILD_DIR := ./build
+DEBUGGER := 1000
+
+# Shared and common source files
+SHARED := ../../shared
+COMMON := ../common
+
+# Add include directories
+INCLUDES += \
+	-I"$(PROJECT_ROOT)/src" \
+	-I"$(PROJECT_ROOT)/system" \
+	-I"$(COMMON)/model/float_genre_ID" \
+	-I"$(COMMON)/model/int8_genre_ID" \
+	-I"$(COMMON)" \
+	-I"$(SHARED)/system" \
+	-I"$(SHARED)"
+
+# Add C sources
+C_SRCS += \
+	$(wildcard $(PROJECT_ROOT)/system/*.c) \
+	$(wildcard $(PROJECT_ROOT)/system/pinmux/GeneratedSources/*.c) \
+	$(wildcard $(PROJECT_ROOT)/system/startup_lsp/lsp/*.c) \
+	$(wildcard $(PROJECT_ROOT)/system/sru/*.c) \
+	$(wildcard $(SHARED)/system/*.c) \
+	$(wildcard $(SHARED)/*.c) \
+	$(wildcard $(COMMON)/*.c)
+
+# Add C++ sources (.cc)
+CC_SRCS += \
+	$(wildcard $(COMMON)/model/float_genre_ID/*.cc) \
+	$(wildcard $(COMMON)/model/int8_genre_ID/*.cc)
+
+# Add C++ sources (.cpp)
+CPP_SRCS += \
+	$(wildcard $(PROJECT_ROOT)/src/*.cpp)
+
+include ../../../tools/sharcfx/project.mk

--- a/examples/keyword_spotter/kws_fileio/Makefile
+++ b/examples/keyword_spotter/kws_fileio/Makefile
@@ -1,0 +1,40 @@
+include ../../../tools/sharcfx/sharcfx.mk
+
+# Initialize project root and build directory
+PROJECT := kws_fileio
+PROJECT_ROOT := .
+BUILD_DIR := ./build
+DEBUGGER := 1000
+
+# Shared and common source files
+SHARED := ../../shared
+COMMON := ../common
+
+# Add include directories
+INCLUDES += \
+	-I"$(PROJECT_ROOT)/src" \
+	-I"$(PROJECT_ROOT)/system" \
+	-I"$(COMMON)/model" \
+	-I"$(COMMON)" \
+	-I"$(SHARED)/system" \
+	-I"$(SHARED)"
+
+# Add C sources
+C_SRCS += \
+	$(wildcard $(PROJECT_ROOT)/system/*.c) \
+	$(wildcard $(PROJECT_ROOT)/system/pinmux/GeneratedSources/*.c) \
+	$(wildcard $(PROJECT_ROOT)/system/startup_lsp/lsp/*.c) \
+	$(wildcard $(PROJECT_ROOT)/system/sru/*.c) \
+	$(wildcard $(SHARED)/system/*.c) \
+	$(wildcard $(SHARED)/*.c) \
+	$(wildcard $(COMMON)/*.c)
+
+# Add C++ sources (.cc)
+CC_SRCS += \
+	$(wildcard $(COMMON)/model/*.cc)
+
+# Add C++ sources (.cpp)
+CPP_SRCS += \
+	$(wildcard $(PROJECT_ROOT)/src/*.cpp)
+
+include ../../../tools/sharcfx/project.mk

--- a/examples/keyword_spotter/kws_realtime/Makefile
+++ b/examples/keyword_spotter/kws_realtime/Makefile
@@ -1,0 +1,53 @@
+include ../../../tools/sharcfx/sharcfx.mk
+
+# Initialize project root and build directory
+PROJECT := kws_realtime
+PROJECT_ROOT := .
+BUILD_DIR := ./build
+DEBUGGER := 1000
+
+# Shared and common source files
+SHARED := ../../shared
+COMMON := ../common
+
+# Add include directories
+INCLUDES += \
+	-I"$(PROJECT_ROOT)/src" \
+	-I"$(PROJECT_ROOT)/system" \
+	-I"$(PROJECT_ROOT)/system/drivers/sport" \
+	-I"$(PROJECT_ROOT)/system/drivers/twi" \
+	-I"$(PROJECT_ROOT)/system/services/pdma" \
+	-I"$(COMMON)/model" \
+	-I"$(COMMON)" \
+	-I"$(SHARED)/system" \
+	-I"$(SHARED)"
+
+# Add C sources
+C_SRCS += \
+	$(wildcard $(PROJECT_ROOT)/system/*.c) \
+	$(wildcard $(PROJECT_ROOT)/system/pinmux/GeneratedSources/*.c) \
+	$(wildcard $(PROJECT_ROOT)/system/startup_lsp/lsp/*.c) \
+	$(wildcard $(PROJECT_ROOT)/system/sru/*.c) \
+	$(wildcard $(SHARED)/system/*.c) \
+	$(wildcard $(SHARED)/*.c) \
+	$(wildcard $(COMMON)/*.c)
+
+# Add C++ sources (.cc)
+CC_SRCS += \
+	$(wildcard $(COMMON)/model/*.cc)
+
+# Add C++ sources (.cpp)
+CPP_SRCS += \
+	$(wildcard $(PROJECT_ROOT)/src/*.cpp)
+
+# Add drivers and services
+SYSCFG_SRCS += \
+	$(DRIVER_DIR)/Source/sport/adi_sport.c \
+	$(DRIVER_DIR)/Source/twi/adi_twi.c \
+	$(DRIVER_DIR)/Source/uart/adi_uart.c \
+	$(SERVICE_DIR)/Source/pdma/adi_pdma.c \
+	$(SERVICE_DIR)/Source/gpio/adi_gpio.c \
+	$(SERVICE_DIR)/Source/pwr/adi_pwr.c \
+	$(SERVICE_DIR)/Source/spu/adi_spu.c
+
+include ../../../tools/sharcfx/project.mk

--- a/examples/shared/system/ConfigSoftSwitches_EV_SC835.c
+++ b/examples/shared/system/ConfigSoftSwitches_EV_SC835.c
@@ -18,7 +18,7 @@ agree to the terms of the associated Analog Devices License Agreement.
  *
  */
 
-#include <drivers\twi\adi_twi_v2.h>
+#include <drivers/twi/adi_twi_v2.h>
 #include "debug.h"
 
 /* TWI settings */

--- a/tools/sharcfx/lib.mk
+++ b/tools/sharcfx/lib.mk
@@ -1,0 +1,62 @@
+# Set up targets
+OBJ_LIST := $(BUILD_DIR)/objs.txt
+LIB_BUILD := $(BUILD_DIR)/$(LIB)
+
+# Set up target objects
+C_OBJS = $(patsubst %.c,$(BUILD_DIR)/%.o,$(subst ./,,$(C_SRCS)))
+CC_OBJS = $(patsubst %.cc,$(BUILD_DIR)/%.o,$(subst ./,,$(CC_SRCS)))
+CPP_OBJS = $(patsubst %.cpp,$(BUILD_DIR)/%.o,$(subst ./,,$(CPP_SRCS)))
+
+SRC_OBJS = $(C_OBJS) $(CC_OBJS) $(CPP_OBJS)
+
+# Initialize flags
+ifeq ($(CONFIG), RELEASE)
+	FLAGS = -proc $(DEVICE) -si-revision 0.0 -c -O3 -LNO:simd -ffunction-sections -fdata-sections -fno-math-errno -mlongcalls -DCORE1 -DUART_REDIRECT -DNDEBUG $(INCLUDES) -MMD -MP
+	CFG_DIR = Release
+else
+	FLAGS = -proc $(DEVICE) -si-revision 0.0 -c -ffunction-sections -fdata-sections -fno-math-errno -mlongcalls -g -DCORE1 -D_DEBUG $(INCLUDES) -MMD -MP
+	CFG_DIR = Debug
+endif
+
+CC_FLAGS = $(FLAGS) -std=c++11 -stdlib=libc++
+C_FLAGS = $(FLAGS)
+
+# Default rule
+all: prebuild $(LIB_BUILD)
+
+# Rule to clean build directory
+clean: 
+	@echo '[RM] $(BUILD_DIR)'
+	@rm -rf $(BUILD_DIR)
+
+prebuild:
+	@echo 'Building $(LIB_BUILD) for $(DEVICE) in $(CONFIG) configuration'
+	@echo 'Using SHARCFX toolchain from $(SHARCFX_ROOT)'
+
+$(LIB_BUILD): $(SRC_OBJS)
+	@echo '[AR] Archiving to $(LIB_BUILD)'
+	@$(AR) -r $(LIB_BUILD) @$(OBJ_LIST)
+	@echo
+	@echo '[AR] Done. See $(LIB_BUILD)'
+	@cp $(LIB_BUILD) $(LIB_SRCS)/../Lib/$(CFG_DIR)/$(LIB)
+	@echo '[CP] $(LIB_BUILD) -> $(LIB_SRCS)/../Lib/$(CFG_DIR)/$(LIB)'
+
+$(BUILD_DIR)/%.o: %.c
+	@mkdir -p $(dir $@)
+	@echo '[CC] $<'
+	@$(CC) $(C_FLAGS) -MF"$(@:%.o=%.d)" -MT"$(@)" -o  "$@" "$<"
+	@echo "\"./$@\"" >> $(OBJ_LIST)
+
+$(BUILD_DIR)/%.o: %.cc
+	@mkdir -p $(dir $@)
+	@echo '[CX] $<'
+	@$(CX) $(CC_FLAGS) -MF"$(@:%.o=%.d)" -MT"$(@)" -o  "$@" "$<"
+	@echo "\"./$@\"" >> $(OBJ_LIST)
+
+$(BUILD_DIR)/%.o: %.cpp
+	@mkdir -p $(dir $@)
+	@echo '[CX] $<'
+	@$(CX) $(CC_FLAGS) -MF"$(@:%.o=%.d)" -MT"$(@)" -o  "$@" "$<"
+	@echo "\"./$@\"" >> $(OBJ_LIST)
+
+.PHONY: all clean

--- a/tools/sharcfx/project.mk
+++ b/tools/sharcfx/project.mk
@@ -1,0 +1,145 @@
+# Set up flashing variables
+MINRT_LSP := $(BUILD_DIR)/flash/min-rt
+FLASH_ALGO := $(SHARCFX_ROOT)/ARM/openocd/share/openocd/scripts/board/flash_algorithms/2183x_flash.dxe
+LSP := $(PROJECT_ROOT)/system/startup_lsp/lsp
+
+ifeq ($(filter $(DEVICE), ADSP-SC835 ADSP-SC835W), $(DEVICE))
+	PRELOADER := $(SHARCFX_ROOT)/Xtensa/SHARC-FX/ldr/ADSPSC835W-EV-SOM_initcode_core1.dxe
+else
+	PRELOADER := $(SHARCFX_ROOT)/Xtensa/SHARC-FX/ldr/ADSP21835W-EV-SOM_initcode_core1.dxe
+endif
+
+TMP := ./tmp
+SHARED_TMP := $(PROJECT_ROOT)/tmp/shared
+COMMON_TMP := $(PROJECT_ROOT)/tmp/common
+
+# Set up project targets
+DXE := $(BUILD_DIR)/$(PROJECT).dxe
+FLASH_DXE := $(BUILD_DIR)/flash/$(PROJECT).dxe
+LDR := $(BUILD_DIR)/flash/$(PROJECT).ldr
+LIBTFLM := $(TFLM_ROOT)/../Lib/Release/libTFLM.a
+LIBNN := $(NN_ROOT)/Lib/Release/libadi_sharcfx_nn.a
+
+# Set up object list
+OBJ_LIST := $(BUILD_DIR)/objs.txt
+
+# Add default headers
+INCLUDES += \
+	-I"$(TFLM_ROOT)" \
+	-I"$(TFLM_ROOT)/third_party/gemmlowp" \
+	-I"$(TFLM_ROOT)/third_party/flatbuffers/include"
+
+
+# Set up target objects
+C_OBJS = $(patsubst %.c,$(BUILD_DIR)/%.o,$(subst ./,,$(patsubst $(COMMON)/%.c, $(COMMON_TMP)/%.c, $(patsubst $(SHARED)/%.c,$(SHARED_TMP)/%.c,$(C_SRCS)))))
+CC_OBJS = $(patsubst %.cc,$(BUILD_DIR)/%.o,$(subst ./,,$(patsubst $(COMMON)/%.cc, $(COMMON_TMP)/%.cc, $(patsubst $(SHARED)/%.cc,$(SHARED_TMP)/%.cc,$(CC_SRCS)))))
+CPP_OBJS = $(patsubst %.cpp,$(BUILD_DIR)/%.o,$(subst ./,,$(patsubst $(COMMON)/%.cpp, $(COMMON_TMP)/%.cpp, $(patsubst $(SHARED)/%.cpp,$(SHARED_TMP)/%.cpp,$(CPP_SRCS)))))
+SYSCFG_OBJS = $(patsubst %.c,$(BUILD_DIR)/%.o,$(subst $(SHARCFX_ROOT)/,,$(subst ./,,$(SYSCFG_SRCS))))
+SRC_OBJS = $(C_OBJS) $(CC_OBJS) $(CPP_OBJS) $(SYSCFG_OBJS)
+FLASH_OBJS = $(filter-out $(BUILD_DIR)/$(subst ./,,$(LSP))/mpu_table.o ,$(SRC_OBJS)) $(MINRT_LSP)/mpu_table.o
+
+# Set base flags based on build configuration
+ifeq ($(CONFIG), RELEASE)
+	FLAGS = -proc $(DEVICE) -si-revision 0.0 -c -O3 -LNO:simd -ffunction-sections -fdata-sections -mlongcalls -DCORE1 -DUART_REDIRECT -DNDEBUG $(INCLUDES) -MMD -MP
+else
+	FLAGS = -proc $(DEVICE) -si-revision 0.0 -c -ffunction-sections -fdata-sections -fno-math-errno -mlongcalls -g -DCORE1 -D_DEBUG $(INCLUDES) -MMD -MP
+endif
+
+# Set compiler flags
+CC_FLAGS = $(FLAGS) -std=c++11 -stdlib=libc++
+C_FLAGS = $(FLAGS)
+L_FLAGS =  -Wl,--gc-sections -Wl,--defsym=__prefctl_default=0x88 -L$(dir $(LIBTFLM)) -L$(dir $(LIBNN)) -lstdc++11 -stdlib=libc++
+CLDP_FLAGS = -cmd prog -erase affected -format bin -driver $(FLASH_ALGO)
+
+# Default rule
+all: build
+
+# Rule to clean build directory
+clean: 
+	@rm -rf $(BUILD_DIR)
+	@echo '[RM] $(BUILD_DIR)'
+	@echo '[RM] $(TMP)'
+	@rm -rf $(TMP)
+
+prebuild: $(TMP) $(MINRT_LSP)
+	@echo '[MK] Building $(PROJECT) for $(DEVICE) in $(CONFIG) configuration'
+	@echo 'Using SHARCFX toolchain from $(SHARCFX_ROOT)'
+
+build: prebuild
+	@$(MAKE) --no-print-directory build-target
+	@rm -rf $(TMP)
+
+# Rule for flashing to target
+flash: prebuild
+	@$(MAKE) --no-print-directory flash-target
+	@echo '[DP] Flashing to $(DEVICE) using $(DEBUGGER)'
+	@$(CLDP) -proc $(DEVICE) -emu $(DEBUGGER) $(CLDP_FLAGS) -file $(LDR)
+
+
+build-target: $(DXE)
+
+flash-target: $(LDR)
+
+# Rule to build C objects
+$(BUILD_DIR)/%.o: %.c
+	@mkdir -p $(dir $@)
+	@echo '[CC] $<'
+	@$(CC) $(C_FLAGS) -MF"$(@:%.o=%.d)" -MT"$(@)" -o  "$@" "$<"
+	@echo "\"./$@\"" >> $(OBJ_LIST)
+
+# Rule to build C++ (.cc) objects
+$(BUILD_DIR)/%.o: %.cc
+	@mkdir -p $(dir $@)
+	@echo '[CX] $<'
+	@$(CX) $(CC_FLAGS) -MF"$(@:%.o=%.d)" -MT"$(@)" -o  "$@" "$<"
+	@echo "\"./$@\"" >> $(OBJ_LIST)
+
+# Rule to build C++ (.cpp) objects
+$(BUILD_DIR)/%.o: %.cpp
+	@mkdir -p $(dir $@)
+	@echo '[CX] $<'
+	@$(CX) $(CC_FLAGS) -MF"$(@:%.o=%.d)" -MT"$(@)" -o  "$@" "$<"
+	@echo "\"./$@\"" >> $(OBJ_LIST)
+
+# Rule to build driver objects
+$(BUILD_DIR)/$(SYSCFG_RDIR)/%.o: $(SYSCFG_DIR)/%.c
+	@mkdir -p $(dir $@)
+	@echo '[CC] $<'
+	@$(CC) $(C_FLAGS) -MF"$(@:%.o=%.d)" -MT"$(@)" -o  "$@" "$<"
+	@echo "\"./$@\"" >> $(OBJ_LIST)
+
+# Rule to compile to executable (.dxe)
+$(DXE): $(SRC_OBJS) $(LIBTFLM) $(LIBNN)
+	@echo '[CX] Linking target to $@'
+	@echo '[CX] Invoking: CrossCore SHARC-FX C++ Linker'
+	@$(CX) -proc $(DEVICE) -si-revision 0.0 -mlsp="$(LSP)" $(L_FLAGS) -o  "$(DXE)" @$(OBJ_LIST) -lTFLM -ladi_sharcfx_nn -lm
+	@echo '[CX] Finished building target: $@'
+
+$(TMP):
+	@mkdir -p $(TMP)
+	@echo '[MK] Fetching shared and common sources'
+	@cp -r --no-preserve=timestamps $(SHARED) $(SHARED_TMP)
+	@echo '[CP] $(SHARED) -> $(SHARED_TMP)'
+	@cp -r --no-preserve=timestamps $(COMMON) $(COMMON_TMP)
+	@echo '[CP] $(COMMON) -> $(COMMON_TMP)'
+
+# Rule to set up LSP for flashing
+$(MINRT_LSP):
+	@echo '[MK] Fetching min-rt LSP for flashing'
+	@mkdir -p $(dir $(MINRT_LSP))
+	@cp -r --no-preserve=timestamps $(SHARCFX_ROOT)/Xtensa/SHARC-FX/lsp/$(DEVICE)/min-rt $(dir $(MINRT_LSP))
+	@echo '[CP] /Xtensa/SHARC-FX/lsp/$(DEVICE)/min-rt -> $(dir $(MINRT_LSP))'
+
+# Rule to compile to executable (.dxe) for flashing
+$(FLASH_DXE): $(FLASH_OBJS)
+	@mkdir -p $(dir $@)
+	@echo '[CX] Linking target to $@'
+	@echo '[CX] Invoking: CrossCore SHARC-FX C++ Linker'
+	@$(CX) -proc $(DEVICE) -si-revision 0.0 -mlsp="$(MINRT_LSP)" $(L_FLAGS) -o  "$(FLASH_DXE)" $(FLASH_OBJS) -lTFLM -ladi_sharcfx_nn -lm
+	@echo '[CX] Finished building target: $@'
+
+# Rule to compile loader image (.ldr) for flashing
+$(LDR): $(FLASH_DXE)
+	@$(ELFLDR) -proc $(DEVICE) -si-revision 0.0 -bspi -fbinary -bcode 1 -init "$(PRELOADER)" -core1="$(FLASH_DXE)"
+
+.PHONY: all clean run flash

--- a/tools/sharcfx/sharcfx.mk
+++ b/tools/sharcfx/sharcfx.mk
@@ -1,0 +1,23 @@
+# Set up roots/directories
+SHARCFX_ROOT := C:/analog/cces/3.0.2
+SHARCFX_ROOT_VER := $(shell echo $(SHARCFX_ROOT) | grep -oP '\d+\.\d+\.\d+')
+TFLM_ROOT := ../../../TFLM/src
+NN_ROOT := ../../../adi_sharcfx_nn
+SYSCFG_RDIR := Xtensa/SHARC-FX/lib/src
+SYSCFG_DIR := $(SHARCFX_ROOT)/$(SYSCFG_RDIR)
+DRIVER_DIR := $(SYSCFG_DIR)/drivers
+SERVICE_DIR := $(SYSCFG_DIR)/services
+MAKE := make
+
+# Set up toolchains
+CX := $(SHARCFX_ROOT)/ccfx++
+CC := $(SHARCFX_ROOT)/ccfx
+AR := $(SHARCFX_ROOT)/Xtensa/XtensaTools/bin/xt-ar
+GDB := $(SHARCFX_ROOT)/Xtensa/XtensaTools/bin/xt-gdb
+RUN := $(SHARCFX_ROOT)/Xtensa/XtensaTools/bin/xt-run
+ELFLDR := $(SHARCFX_ROOT)/elfloader
+CLDP := $(SHARCFX_ROOT)/cldp
+
+# Set up default variables
+DEVICE := ADSP-SC835
+CONFIG := RELEASE


### PR DESCRIPTION
This pull request changes the following:

- Add gitignore entry for `tmp/` directories. `tmp` is used for building example projects.
- Fix path naming for ConfigSoftSwitches_EV_SC835 to make header unix-compatible.
- Add base makefiles for building TFLM library, NN library, and example projects for SHARC-FX.
- Add shell script counterpart for generating tflite models.
- Add additional workflows for denoiser, kws, and genre_id example project.